### PR TITLE
Add missing require statement

### DIFF
--- a/lib/op_connect/object.rb
+++ b/lib/op_connect/object.rb
@@ -1,3 +1,4 @@
+require "delegate"
 require "ostruct"
 
 module OpConnect


### PR DESCRIPTION
I added the missing require statement for SimpleDelegator. This could lead to a NameError if "delegate" was not required before.

```
op_connect-0.1.3/lib/op_connect/object.rb:4:in `<module:OpConnect>': uninitialized constant OpConnect::SimpleDe
legator (NameError)

  class Object < SimpleDelegator
                 ^^^^^^^^^^^^^^^
```